### PR TITLE
Virtual vsync

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,3 +51,103 @@ tbd...
 ## References
 
 [TetraPolyscope](https://github.com/i-geng/polyscope)
+
+
+
+## MoltenVK supported device extensions
+Device Extensions: count = 94
+        VK_AMD_gpu_shader_half_float              : extension revision 2
+        VK_AMD_negative_viewport_height           : extension revision 1
+        VK_AMD_shader_image_load_store_lod        : extension revision 1
+        VK_AMD_shader_trinary_minmax              : extension revision 1
+        VK_EXT_4444_formats                       : extension revision 1
+        VK_EXT_buffer_device_address              : extension revision 2
+        VK_EXT_calibrated_timestamps              : extension revision 2
+        VK_EXT_debug_marker                       : extension revision 4
+        VK_EXT_descriptor_indexing                : extension revision 2
+        VK_EXT_extended_dynamic_state             : extension revision 1
+        VK_EXT_extended_dynamic_state2            : extension revision 1
+        VK_EXT_extended_dynamic_state3            : extension revision 2
+        VK_EXT_external_memory_host               : extension revision 1
+        VK_EXT_fragment_shader_interlock          : extension revision 1
+        VK_EXT_hdr_metadata                       : extension revision 2
+        VK_EXT_host_image_copy                    : extension revision 1
+        VK_EXT_host_query_reset                   : extension revision 1
+        VK_EXT_image_robustness                   : extension revision 1
+        VK_EXT_inline_uniform_block               : extension revision 1
+        VK_EXT_memory_budget                      : extension revision 1
+        VK_EXT_metal_objects                      : extension revision 2
+        VK_EXT_pipeline_creation_cache_control    : extension revision 3
+        VK_EXT_pipeline_creation_feedback         : extension revision 1
+        VK_EXT_post_depth_coverage                : extension revision 1
+        VK_EXT_private_data                       : extension revision 1
+        VK_EXT_robustness2                        : extension revision 1
+        VK_EXT_sample_locations                   : extension revision 1
+        VK_EXT_scalar_block_layout                : extension revision 1
+        VK_EXT_separate_stencil_usage             : extension revision 1
+        VK_EXT_shader_atomic_float                : extension revision 1
+        VK_EXT_shader_demote_to_helper_invocation : extension revision 1
+        VK_EXT_shader_stencil_export              : extension revision 1
+        VK_EXT_shader_subgroup_ballot             : extension revision 1
+        VK_EXT_shader_subgroup_vote               : extension revision 1
+        VK_EXT_shader_viewport_index_layer        : extension revision 1
+        VK_EXT_subgroup_size_control              : extension revision 2
+        VK_EXT_swapchain_maintenance1             : extension revision 1
+        VK_EXT_texel_buffer_alignment             : extension revision 1
+        VK_EXT_texture_compression_astc_hdr       : extension revision 1
+        VK_EXT_vertex_attribute_divisor           : extension revision 3
+        VK_GOOGLE_display_timing                  : extension revision 1
+        VK_IMG_format_pvrtc                       : extension revision 1
+        VK_INTEL_shader_integer_functions2        : extension revision 1
+        VK_KHR_16bit_storage                      : extension revision 1
+        VK_KHR_8bit_storage                       : extension revision 1
+        VK_KHR_bind_memory2                       : extension revision 1
+        VK_KHR_buffer_device_address              : extension revision 1
+        VK_KHR_calibrated_timestamps              : extension revision 1
+        VK_KHR_copy_commands2                     : extension revision 1
+        VK_KHR_create_renderpass2                 : extension revision 1
+        VK_KHR_dedicated_allocation               : extension revision 3
+        VK_KHR_deferred_host_operations           : extension revision 4
+        VK_KHR_depth_stencil_resolve              : extension revision 1
+        VK_KHR_descriptor_update_template         : extension revision 1
+        VK_KHR_device_group                       : extension revision 4
+        VK_KHR_driver_properties                  : extension revision 1
+        VK_KHR_dynamic_rendering                  : extension revision 1
+        VK_KHR_external_fence                     : extension revision 1
+        VK_KHR_external_memory                    : extension revision 1
+        VK_KHR_external_semaphore                 : extension revision 1
+        VK_KHR_format_feature_flags2              : extension revision 2
+        VK_KHR_fragment_shader_barycentric        : extension revision 1
+        VK_KHR_get_memory_requirements2           : extension revision 1
+        VK_KHR_image_format_list                  : extension revision 1
+        VK_KHR_imageless_framebuffer              : extension revision 1
+        VK_KHR_incremental_present                : extension revision 2
+        VK_KHR_maintenance1                       : extension revision 2
+        VK_KHR_maintenance2                       : extension revision 1
+        VK_KHR_maintenance3                       : extension revision 1
+        VK_KHR_map_memory2                        : extension revision 1
+        VK_KHR_multiview                          : extension revision 1
+        VK_KHR_portability_subset                 : extension revision 1
+        VK_KHR_push_descriptor                    : extension revision 2
+        VK_KHR_relaxed_block_layout               : extension revision 1
+        VK_KHR_sampler_mirror_clamp_to_edge       : extension revision 3
+        VK_KHR_sampler_ycbcr_conversion           : extension revision 14
+        VK_KHR_separate_depth_stencil_layouts     : extension revision 1
+        VK_KHR_shader_draw_parameters             : extension revision 1
+        VK_KHR_shader_float16_int8                : extension revision 1
+        VK_KHR_shader_float_controls              : extension revision 4
+        VK_KHR_shader_integer_dot_product         : extension revision 1
+        VK_KHR_shader_non_semantic_info           : extension revision 1
+        VK_KHR_shader_subgroup_extended_types     : extension revision 1
+        VK_KHR_spirv_1_4                          : extension revision 1
+        VK_KHR_storage_buffer_storage_class       : extension revision 1
+        VK_KHR_swapchain                          : extension revision 70
+        VK_KHR_swapchain_mutable_format           : extension revision 1
+        VK_KHR_synchronization2                   : extension revision 1
+        VK_KHR_timeline_semaphore                 : extension revision 2
+        VK_KHR_uniform_buffer_standard_layout     : extension revision 1
+        VK_KHR_variable_pointers                  : extension revision 1
+        VK_KHR_vertex_attribute_divisor           : extension revision 1
+        VK_NV_fragment_shader_barycentric         : extension revision 1
+        VK_NV_glsl_shader                         : extension revision 1
+

--- a/src/VulkanEngine.cpp
+++ b/src/VulkanEngine.cpp
@@ -1884,7 +1884,6 @@ uint64_t VulkanEngine::getSurfaceCounterValue()
         );
         std::vector<VkPastPresentationTimingGOOGLE> images(imageCount);
 
-        INFO("{}", imageCount);
         vkGetPastPresentationTimingGOOGLE(
             _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, images.data()
         );

--- a/src/VulkanEngine.cpp
+++ b/src/VulkanEngine.cpp
@@ -580,6 +580,23 @@ void VulkanEngine::Tick()
     }
     _lastProfilerData = _profiler.NewProfile();
     _numTicks++;
+    // experimental stuff
+    static std::map<uint32_t, uint64_t> m;
+    // uint32_t imageCount;
+    // VK_CHECK_RESULT(vkGetPastPresentationTimingGOOGLE(_device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, nullptr))
+    // std::vector<VkPastPresentationTimingGOOGLE> vec(imageCount);
+    // VK_CHECK_RESULT(vkGetPastPresentationTimingGOOGLE(_device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, vec.data()))
+    // for (auto& elem : vec) {
+    //     auto it = m.insert({elem.presentID, static_cast<unsigned int>(elem.actualPresentTime)});
+    // }
+    // if (m.size() > 30) {
+    //     for (auto it = m.begin(); it != m.end(); it++) {
+    //         fmt::println("{} {}", it->first, it->second);
+    //     }
+    //     exit(0);
+    // } else {
+    //     fmt::println("{}", m.size());
+    // }
 }
 
 void VulkanEngine::framebufferResizeCallback(GLFWwindow* window, int width, int height)

--- a/src/VulkanEngine.cpp
+++ b/src/VulkanEngine.cpp
@@ -1879,18 +1879,15 @@ uint64_t VulkanEngine::getSurfaceCounterValue()
         // TODO: need to validate the delay,
         // benchmark it against old software method
         uint32_t imageCount;
-        VK_CHECK_RESULT(vkGetPastPresentationTimingGOOGLE(
+        vkGetPastPresentationTimingGOOGLE(
             _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, nullptr
-        ))
-        // std::vector<VkPastPresentationTimingGOOGLE> vec(imageCount);
-        const int IMAGE_BUFFER_SIZE = 2;
-        std::array<VkPastPresentationTimingGOOGLE, IMAGE_BUFFER_SIZE> images;
+        );
+        std::vector<VkPastPresentationTimingGOOGLE> images(imageCount);
 
-        ASSERT(imageCount <= IMAGE_BUFFER_SIZE);
         INFO("{}", imageCount);
-        VK_CHECK_RESULT(vkGetPastPresentationTimingGOOGLE(
+        vkGetPastPresentationTimingGOOGLE(
             _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, images.data()
-        ));
+        );
         for (int i = 0; i < imageCount; i++) {
             _softwareEvenOddCtx.lastPresentedImageId
                 = std::max(_softwareEvenOddCtx.lastPresentedImageId, images.at(i).presentID);

--- a/src/VulkanEngine.cpp
+++ b/src/VulkanEngine.cpp
@@ -762,7 +762,7 @@ void VulkanEngine::initVulkan()
     this->_deletionStack.push([this]() { this->cleanupSwapChain(_mainWindowSwapChain); });
 
     this->createImageViews(_mainWindowSwapChain);
-    this->createMainRenderPass(_mainWindowSwapChain);
+    this->createMainRenderPass(_mainWindowSwapChain.imageFormat);
     this->createDepthBuffer(_mainWindowSwapChain);
     this->createSynchronizationObjects(_syncProjector);
     this->_imguiManager.InitializeRenderPass(
@@ -1335,11 +1335,11 @@ void VulkanEngine::Cleanup()
     INFO("Resource cleaned up.");
 }
 
-void VulkanEngine::createMainRenderPass(VulkanEngine::SwapChainContext& ctx)
+void VulkanEngine::createMainRenderPass(const VkFormat imageFormat)
 {
     DEBUG("Creating render pass...");
     VkAttachmentDescription colorAttachment{};
-    colorAttachment.format = ctx.imageFormat;
+    colorAttachment.format = imageFormat;
     colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
 
     colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;

--- a/src/VulkanEngine.cpp
+++ b/src/VulkanEngine.cpp
@@ -1884,13 +1884,19 @@ uint64_t VulkanEngine::getSurfaceCounterValue()
         VK_CHECK_RESULT(vkGetPastPresentationTimingGOOGLE(
             _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, nullptr
         ))
-        std::vector<VkPastPresentationTimingGOOGLE> vec(imageCount);
+        //std::vector<VkPastPresentationTimingGOOGLE> vec(imageCount);
+        const int IMAGE_BUFFER_SIZE = 2;
+        std::array<VkPastPresentationTimingGOOGLE, IMAGE_BUFFER_SIZE> images;
+
+        ASSERT(imageCount <= IMAGE_BUFFER_SIZE);
+        INFO("{}", imageCount);
         VK_CHECK_RESULT(vkGetPastPresentationTimingGOOGLE(
-            _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, vec.data()
+            _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, images.data()
         ));
-        for (auto& elem : vec) {
-            _softwareEvenOddCtx.presentedImageIds.insert(elem.presentID);
+        for (int i = 0; i < imageCount; i++) {
+            _softwareEvenOddCtx.presentedImageIds.insert(images.at(i).presentID);
         }
+
         surfaceCounter = _softwareEvenOddCtx.presentedImageIds.size();
         // old method: count the time
         // return a software-based surface counter

--- a/src/VulkanEngine.cpp
+++ b/src/VulkanEngine.cpp
@@ -1577,7 +1577,7 @@ void VulkanEngine::drawFrame(TickContext* ctx, uint8_t frame)
             vk::Rect2D renderArea(VkOffset2D{0, 0}, extend);
             vk::RenderPassBeginInfo renderPassBeginInfo(
                 _mainRenderPass,
-                FB,
+                FB, // which frame buffer in the swapchain do the pass i.e. all draw calls render to?
                 renderArea,
                 _mainRenderPassClearValues.size(),
                 _mainRenderPassClearValues.data(),

--- a/src/VulkanEngine.cpp
+++ b/src/VulkanEngine.cpp
@@ -1226,7 +1226,7 @@ VkPresentModeKHR VulkanEngine::chooseSwapPresentMode(
     const std::vector<VkPresentModeKHR>& availablePresentModes
 )
 {
-    //return VK_PRESENT_MODE_IMMEDIATE_KHR; force immediate mode
+    // return VK_PRESENT_MODE_IMMEDIATE_KHR; force immediate mode
     INFO("available present modes: ");
     for (const auto& availablePresentMode : availablePresentModes) {
         INFO("{}", string_VkPresentModeKHR(availablePresentMode));
@@ -1676,9 +1676,7 @@ void VulkanEngine::drawFrame(TickContext* ctx, uint8_t frame)
     uint64_t time = 0; // no early time limit
 
     // label each frame with the tick number
-    VkPresentTimeGOOGLE presentTime{
-        (uint32_t)_numTicks, time
-    };
+    VkPresentTimeGOOGLE presentTime{(uint32_t)_numTicks, time};
 
     VkPresentTimesInfoGOOGLE presentTimeInfo{
         .sType = VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE,
@@ -1884,7 +1882,7 @@ uint64_t VulkanEngine::getSurfaceCounterValue()
         VK_CHECK_RESULT(vkGetPastPresentationTimingGOOGLE(
             _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, nullptr
         ))
-        //std::vector<VkPastPresentationTimingGOOGLE> vec(imageCount);
+        // std::vector<VkPastPresentationTimingGOOGLE> vec(imageCount);
         const int IMAGE_BUFFER_SIZE = 2;
         std::array<VkPastPresentationTimingGOOGLE, IMAGE_BUFFER_SIZE> images;
 
@@ -1894,10 +1892,11 @@ uint64_t VulkanEngine::getSurfaceCounterValue()
             _device->logicalDevice, _mainWindowSwapChain.chain, &imageCount, images.data()
         ));
         for (int i = 0; i < imageCount; i++) {
-            _softwareEvenOddCtx.presentedImageIds.insert(images.at(i).presentID);
+            _softwareEvenOddCtx.lastPresentedImageId
+                = std::max(_softwareEvenOddCtx.lastPresentedImageId, images.at(i).presentID);
         }
 
-        surfaceCounter = _softwareEvenOddCtx.presentedImageIds.size();
+        surfaceCounter = _softwareEvenOddCtx.lastPresentedImageId;
         // old method: count the time
         // return a software-based surface counter
         // if (0) {

--- a/src/VulkanEngine.h
+++ b/src/VulkanEngine.h
@@ -305,12 +305,17 @@ class VulkanEngine
     // context for software-based even-odd frame sync
     struct {
         std::chrono::time_point<std::chrono::steady_clock> timeEngineStart;
-        uint64_t nanoSecondsPerFrame;
+        uint64_t nanoSecondsPerFrame; // how many nanoseconds in between frames?
+                                      // obtained through a precise vulkan API call
         int timeOffset = 0; // time offset added to the time that's used
-                             // to evaluate current frame.
-        long clockTimeBegin = 0; // obtained from clock_gettime
-        long mostRecentPresentFinish = 0;
-        uint32_t lastPresentedImageId = 0;
+                             // to evaluate current frame, used for the old counter method
+        long clockTimeBegin = 0; // obtained from clock_gettime, unused
+        long mostRecentPresentFinish = 0; // unused
+        uint32_t lastPresentedImageId = 0; // each image are tagged with an image id,
+                                           // image id corresponds to the tick # 
+                                           // when the images are presented
+                                           // tick # and image id are bijective and they
+                                           // strictly increase over time
     } _softwareEvenOddCtx;
 
     /* ---------- Engine Components ---------- */

--- a/src/VulkanEngine.h
+++ b/src/VulkanEngine.h
@@ -185,7 +185,7 @@ class VulkanEngine
     void createGlfwWindowSurface();
     void createDevice();
     VkSurfaceKHR createGlfwWindowSurface(GLFWwindow* window);
-    void createMainRenderPass(VulkanEngine::SwapChainContext& ctx); // create main render pass
+    void createMainRenderPass(const VkFormat imageFormat); // create main render pass
     void createSynchronizationObjects(std::array<SyncPrimitives, NUM_FRAME_IN_FLIGHT>& primitives);
     void createFunnyObjects();
 

--- a/src/VulkanEngine.h
+++ b/src/VulkanEngine.h
@@ -78,6 +78,7 @@ class VulkanEngine
 #endif // __APPLE__
        //https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetRefreshCycleDurationGOOGLE.html
        //https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPastPresentationTimingGOOGLE.html
+       //https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPresentTimesInfoGOOGLE.html
         VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME // for query refresh rate
     };
 
@@ -291,7 +292,7 @@ class VulkanEngine
     float _FOV = 90;
     double _timeSinceStartSeconds; // seconds in time since engine start, regardless of pause
     unsigned long int _timeSinceStartNanoSeconds; // nanoseconds in time since engine start, regardless of pause
-    unsigned long int _numTicks;  // how many ticks has happened so far
+    unsigned long int _numTicks=0;  // how many ticks has happened so far
 
     // even-odd frame
     bool _flipEvenOdd = false; // whether to flip even-odd frame
@@ -305,8 +306,10 @@ class VulkanEngine
     struct {
         std::chrono::time_point<std::chrono::steady_clock> timeEngineStart;
         uint64_t nanoSecondsPerFrame;
-        int timeOffset; // time offset added to the time that's used
+        int timeOffset = 0; // time offset added to the time that's used
                              // to evaluate current frame.
+        long clockTimeBegin = 0; // obtained from clock_gettime
+        long mostRecentPresentFinish = 0;
     } _softwareEvenOddCtx;
 
     /* ---------- Engine Components ---------- */

--- a/src/VulkanEngine.h
+++ b/src/VulkanEngine.h
@@ -310,6 +310,7 @@ class VulkanEngine
                              // to evaluate current frame.
         long clockTimeBegin = 0; // obtained from clock_gettime
         long mostRecentPresentFinish = 0;
+        std::unordered_set<uint32_t> presentedImageIds; // set of all images that has been presented
     } _softwareEvenOddCtx;
 
     /* ---------- Engine Components ---------- */

--- a/src/VulkanEngine.h
+++ b/src/VulkanEngine.h
@@ -310,7 +310,7 @@ class VulkanEngine
                              // to evaluate current frame.
         long clockTimeBegin = 0; // obtained from clock_gettime
         long mostRecentPresentFinish = 0;
-        std::unordered_set<uint32_t> presentedImageIds; // set of all images that has been presented
+        uint32_t lastPresentedImageId;
     } _softwareEvenOddCtx;
 
     /* ---------- Engine Components ---------- */

--- a/src/VulkanEngine.h
+++ b/src/VulkanEngine.h
@@ -310,7 +310,7 @@ class VulkanEngine
                              // to evaluate current frame.
         long clockTimeBegin = 0; // obtained from clock_gettime
         long mostRecentPresentFinish = 0;
-        uint32_t lastPresentedImageId;
+        uint32_t lastPresentedImageId = 0;
     } _softwareEvenOddCtx;
 
     /* ---------- Engine Components ---------- */

--- a/src/ecs/system/SimpleRenderSystem.cpp
+++ b/src/ecs/system/SimpleRenderSystem.cpp
@@ -53,8 +53,6 @@ void SimpleRenderSystem::Cleanup()
 void SimpleRenderSystem::Tick(const TickContext* tickData)
 {
     VkCommandBuffer CB = tickData->graphics.CB;
-    VkFramebuffer FB = tickData->graphics.currentFB;
-    VkExtent2D FBExt = tickData->graphics.currentFBextend;
     int frameIdx = tickData->graphics.currentFrameInFlight;
 
     vkCmdBindPipeline(CB, VK_PIPELINE_BIND_POINT_GRAPHICS, _pipeline);


### PR DESCRIPTION
refactored the existing virtual(software) surface counter method, also added a new virtual counter method.

The old virtual counter's base unit(frame in nanoseconds) is now obtained from a precise Vulkan API call;
The new virtual counter does the counting by taking the maximum of the committed frame ids. Each presented frame is tagged with a strictly-increasing id.

Need to benchmark new method vs. old method

various virtual counter clean-up.